### PR TITLE
Update repository and pullPolicy

### DIFF
--- a/chart/nodeserver/values.yaml
+++ b/chart/nodeserver/values.yaml
@@ -3,9 +3,9 @@
 replicaCount: 1
 revisionHistoryLimit: 1
 image:
-  repository: cnbailey/nodeserver
+  repository: nodeserver
   tag: 1.0.0
-  pullPolicy: Always
+  pullPolicy: IfNotPresent 
   resources:
     requests:
       cpu: 200m


### PR DESCRIPTION
This PR removes `cnbailey` from the repository in the values.yaml, and changes the pullPolicy to `IfNotPresent`. This changes the policy so that it can use a local version of the Docker image if present (which is required if you want to run with a local Kubernetes install on your laptop).