### PR TITLE
fix(template): not working with k8s v1.16.0

### DIFF
--- a/chart/nodeserver/templates/basedeployment.yaml
+++ b/chart/nodeserver/templates/basedeployment.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.base.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{  .Chart.Name }}-basedeployment"
@@ -12,6 +12,10 @@ spec:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+  selector:
+    matchLabels:
+      app: "{{  .Chart.Name }}-selector"
+      version: "base"
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:

--- a/chart/nodeserver/templates/deployment.yaml
+++ b/chart/nodeserver/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{  .Chart.Name }}-deployment"
@@ -11,6 +11,10 @@ spec:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+  selector:
+    matchLabels:
+      app: "{{  .Chart.Name }}-selector"
+      version: "current"
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:


### PR DESCRIPTION
This PR closes the issue  #3 

As [the k8s official articles](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) says, those deprecated APIs were removed In 1.16, so I think it's safe to update the API version of `Deployment`.

> - DaemonSet, Deployment, StatefulSet, and ReplicaSet (in the extensions/v1beta1 and apps/v1beta2 API groups)
>   - Migrate to use the apps/v1 API, available since v1.9. Existing persisted data can be retrieved/updated via the apps/v1 API.